### PR TITLE
Move plugincoreopts into core. So plugins less likely to have to pull…

### DIFF
--- a/plugincoreopts/buildopts.go
+++ b/plugincoreopts/buildopts.go
@@ -1,0 +1,26 @@
+package plugincoreopts
+
+type Option func(*OptionsBuilder)
+
+type OptionsBuilder struct {
+	IsPluginHardwired func() bool
+}
+
+func LoadOptions() Option {
+	return func(optionsBuilder *OptionsBuilder) {
+		optionsBuilder.IsPluginHardwired = IsPluginHardwired
+	}
+}
+
+var BuildOptions *OptionsBuilder
+
+func NewOptionsBuilder(opts ...Option) {
+	BuildOptions = &OptionsBuilder{}
+	for _, opt := range opts {
+		opt(BuildOptions)
+	}
+}
+
+func init() {
+	NewOptionsBuilder(LoadOptions())
+}

--- a/plugincoreopts/pluginopts.go
+++ b/plugincoreopts/pluginopts.go
@@ -1,0 +1,9 @@
+//go:build !hardwired
+// +build !hardwired
+
+package plugincoreopts
+
+// IsPluginHardwired - Override to hardwire plugins into the kernel for debugging.
+func IsPluginHardwired() bool {
+	return false
+}

--- a/plugincoreopts/pluginopts_hardwired.go
+++ b/plugincoreopts/pluginopts_hardwired.go
@@ -1,0 +1,9 @@
+//go:build hardwired
+// +build hardwired
+
+package plugincoreopts
+
+// IsPluginHardwired - Override to hardwire plugins into the kernel for debugging.
+func IsPluginHardwired() bool {
+	return true
+}


### PR DESCRIPTION
… in tierceron.